### PR TITLE
bug fix with presence when queue ends and no songs left

### DIFF
--- a/blues_bot/src/events.py
+++ b/blues_bot/src/events.py
@@ -351,6 +351,7 @@ class EventMessage:
             await self._goodbye(client, message)
             await voice_client.disconnect()
             self.first_flag = False
+            await self._change_status(client, None)
 
     async def _change_status(self, client, song_name):
         """Changes the status of the bot


### PR DESCRIPTION
Previously when queue ran out the bots 'now playing' stayed showing ```now playing <last song on queue>``` this has been fixed so when the queue runs out the bots now playing goes back to nothing.